### PR TITLE
Add scroll snapping and unified animations

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -3,10 +3,10 @@ import type { ReactNode } from 'react';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <div>
+    <>
       {children}
       <Footer />
-    </div>
+    </>
   );
 };
 

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -32,6 +32,8 @@ const query = groq`
   "home": *[_type == "home"][0],
   "whatWeDo": *[_type == "whatWeDo"][0] {
     heading,
+    graySubHeading,
+    blueSubHeading,
     cards[] {
       title,
       subtitle,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} snap-y snap-mandatory overflow-y-scroll antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} snap-y snap-proximity antialiased`}
       >
         <Navbar />
         <div className="pt-16">{children}</div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} snap-y snap-mandatory overflow-y-scroll antialiased`}
       >
         <Navbar />
         <div className="pt-16">{children}</div>

--- a/components/faqs-section.tsx
+++ b/components/faqs-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion, useReducedMotion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import {
   Accordion,
   AccordionItem,
@@ -17,9 +18,13 @@ export default function FaqSection({ faq }: FaqProps) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
-      className="bg-accent min-h-[calc(100dvh-96px)] scroll-mt-24 py-12 text-white"
+    <motion.section
+      className="bg-accent min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 py-12 text-white"
       id="faq"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       {/* Heading */}
       <motion.h2
@@ -62,6 +67,6 @@ export default function FaqSection({ faq }: FaqProps) {
             : null}
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/components/faqs-section.tsx
+++ b/components/faqs-section.tsx
@@ -19,7 +19,7 @@ export default function FaqSection({ faq }: FaqProps) {
 
   return (
     <motion.section
-      className="bg-accent min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 py-12 text-white"
+      className="bg-accent min-h-[calc(100dvh-96px)] scroll-mt-24 py-12 text-white"
       id="faq"
       initial={shouldReduce ? {} : 'hidden'}
       whileInView="show"

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { urlFor } from '@/lib/sanity/client';
 import type { Hero } from '@/lib/sanity/types';
 import Image from 'next/image';
-import { fadeUp } from '@/lib/motion';
+import { fadeUp, fadeIn } from '@/lib/motion';
 import { Button } from './ui/button';
 import { ArrowRight } from 'lucide-react';
 
@@ -16,16 +16,26 @@ export default function HeroSection({ hero }: { hero: Hero }) {
     : '';
 
   return (
-    <div className="flex h-screen flex-col gap-12 px-4">
+    <div className="flex h-screen snap-start flex-col gap-12 px-4">
       {/* HERO */}
       <motion.section
         className="flex flex-col items-center gap-4 pt-8"
         initial={shouldReduce ? undefined : 'hidden'}
         animate="show"
-        variants={{
-          hidden: {},
-          show: { transition: { staggerChildren: 0.2 } },
-        }}
+        variants={
+          shouldReduce
+            ? {}
+            : {
+                hidden: fadeIn.hidden,
+                show: {
+                  ...fadeIn.show,
+                  transition: {
+                    ...fadeIn.show.transition,
+                    staggerChildren: 0.2,
+                  },
+                },
+              }
+        }
       >
         {imgSrc && (
           <motion.div

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useReducedMotion, motion } from 'framer-motion';
+import { useReducedMotion, motion, TargetAndTransition } from 'framer-motion';
 import Link from 'next/link';
 import { urlFor } from '@/lib/sanity/client';
 import type { Hero } from '@/lib/sanity/types';
@@ -16,7 +16,7 @@ export default function HeroSection({ hero }: { hero: Hero }) {
     : '';
 
   return (
-    <div className="flex h-screen snap-start flex-col gap-12 px-4">
+    <div className="flex h-screen flex-col gap-12 px-4">
       {/* HERO */}
       <motion.section
         className="flex flex-col items-center gap-4 pt-8"
@@ -30,7 +30,7 @@ export default function HeroSection({ hero }: { hero: Hero }) {
                 show: {
                   ...fadeIn.show,
                   transition: {
-                    ...fadeIn.show.transition,
+                    ...(fadeIn.show as TargetAndTransition).transition,
                     staggerChildren: 0.2,
                   },
                 },
@@ -75,7 +75,7 @@ export default function HeroSection({ hero }: { hero: Hero }) {
       >
         {hero.ctas?.map((cta) => (
           <motion.div
-            key={cta._key}
+            key={cta.text}
             variants={shouldReduce ? {} : fadeUp}
             className="group border-border bg-card relative flex h-full flex-col justify-between rounded-2xl border p-6 shadow-sm transition-shadow hover:shadow-md"
           >

--- a/components/our-approach.tsx
+++ b/components/our-approach.tsx
@@ -31,7 +31,7 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
 
   return (
     <motion.section
-      className="relative h-[2400px] snap-start scroll-mt-24 py-12"
+      className="relative h-[2400px] scroll-mt-24 py-12"
       ref={containerRef}
       id="how-we-work"
       initial={shouldReduce ? {} : 'hidden'}

--- a/components/our-approach.tsx
+++ b/components/our-approach.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react';
 import Lenis from 'lenis';
 import { useScroll, motion, useReducedMotion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import type { OurApproach } from '@/lib/sanity/types';
 import ApproachCard from './approach-card';
 
@@ -29,10 +30,14 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
-      className="relative h-[2400px] scroll-mt-24 py-12"
+    <motion.section
+      className="relative h-[2400px] snap-start scroll-mt-24 py-12"
       ref={containerRef}
       id="how-we-work"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       <motion.div
         className="sticky top-[20vh] container mx-auto mb-4 max-w-[700px] px-4"
@@ -76,6 +81,6 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
           );
         })}
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/components/use-cases.tsx
+++ b/components/use-cases.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { motion, useReducedMotion, Variants } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import {
   Card,
   CardContent,
@@ -37,11 +38,11 @@ export const UseCases = ({ useCaseSection }: UseCasesProps) => {
   return (
     <motion.section
       id="use-cases"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white px-8 py-12 text-gray-900"
-      initial={shouldReduce ? {} : { opacity: 0, y: 20 }}
-      whileInView={shouldReduce ? {} : { opacity: 1, y: 0 }}
+      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white px-8 py-12 text-gray-900"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
       viewport={{ once: true, amount: 0.3 }}
-      transition={{ duration: 0.6 }}
+      variants={fadeIn}
     >
       <div className="mx-auto grid max-w-7xl grid-cols-1 gap-12 md:grid-cols-2">
         {/* Left Intro */}

--- a/components/use-cases.tsx
+++ b/components/use-cases.tsx
@@ -38,7 +38,7 @@ export const UseCases = ({ useCaseSection }: UseCasesProps) => {
   return (
     <motion.section
       id="use-cases"
-      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white px-8 py-12 text-gray-900"
+      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white px-8 py-12 text-gray-900"
       initial={shouldReduce ? {} : 'hidden'}
       whileInView="show"
       viewport={{ once: true, amount: 0.3 }}

--- a/components/what-we-do.tsx
+++ b/components/what-we-do.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useReducedMotion, motion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import type { WhatWeDo, WhatWeDoItem } from '@/lib/sanity/types';
@@ -20,9 +21,13 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
+    <motion.section
       id="what-we-do"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white py-12"
+      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white py-12"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       <div className="container mx-auto mb-12 px-4 text-center">
         <h2 className="text-4xl font-extrabold text-gray-900">
@@ -97,6 +102,6 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
           );
         })}
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/components/what-we-do.tsx
+++ b/components/what-we-do.tsx
@@ -5,17 +5,10 @@ import { fadeIn } from '@/lib/motion';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import type { WhatWeDo, WhatWeDoItem } from '@/lib/sanity/types';
-import { Database, Lightbulb, TrendingUp } from 'lucide-react';
 
 interface WhatWeDoProps {
   whatWeDo: WhatWeDo;
 }
-
-const ICON_MAP: Record<string, typeof Database> = {
-  KNOW: Database,
-  DO: Lightbulb,
-  DECIDE: TrendingUp,
-};
 
 export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
   const shouldReduce = useReducedMotion();
@@ -23,7 +16,7 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
   return (
     <motion.section
       id="what-we-do"
-      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white py-12"
+      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white py-12"
       initial={shouldReduce ? {} : 'hidden'}
       whileInView="show"
       viewport={{ once: true, amount: 0.3 }}
@@ -33,6 +26,16 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
         <h2 className="text-4xl font-extrabold text-gray-900">
           {whatWeDo.heading}
         </h2>
+        {whatWeDo.graySubHeading && (
+          <p className="max-w-3xl pl-13 text-2xl text-gray-400">
+            {whatWeDo.graySubHeading}
+          </p>
+        )}
+        {whatWeDo.blueSubHeading && (
+          <p className="text-accent max-w-3xl pl-13 text-2xl">
+            {whatWeDo.blueSubHeading}
+          </p>
+        )}
       </div>
 
       <div className="container mx-auto grid gap-8 px-4 md:grid-cols-3">
@@ -46,10 +49,6 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
             if (blue[i]) lines.push({ text: blue[i], color: 'blue' });
             if (gray[i]) lines.push({ text: gray[i], color: 'gray' });
           }
-
-          const Icon = card.title
-            ? ICON_MAP[card.title.toUpperCase()]
-            : Database;
 
           return (
             <motion.div
@@ -65,7 +64,6 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
 
               {/* Header with icon */}
               <div className="relative z-10 flex items-center space-x-3 bg-black px-6 py-4 text-white">
-                <Icon className="group-hover:text-accent h-6 w-6 text-gray-400 transition-colors duration-200" />
                 <div>
                   <h3 className="text-2xl font-bold uppercase">{card.title}</h3>
                   <p className="mt-1 text-lg text-gray-300">{card.subtitle}</p>

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -11,3 +11,15 @@ export const fadeUp: Variants = {
     },
   },
 };
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: [0.25, 0.1, 0.25, 1],
+    },
+  },
+};

--- a/lib/sanity/types.ts
+++ b/lib/sanity/types.ts
@@ -301,6 +301,8 @@ export type WhatWeDo = {
   _updatedAt: string;
   _rev: string;
   heading?: string;
+  graySubHeading?: string;
+  blueSubHeading?: string;
   cards?: Array<
     {
       _key: string;
@@ -435,7 +437,7 @@ export type AllSanitySchemaTypes =
 export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: ../kf-website-frontend/app/(home)/page.tsx
 // Variable: query
-// Query: {  "hero": *[_type == "hero"][0] {    heading,    headingBlue,    image {      asset,      alt    }  },  "home": *[_type == "home"][0],  "whatWeDo": *[_type == "whatWeDo"][0] {    heading,    cards[] {      title,      subtitle,      buttonText,      buttonLink,      blueLines,      grayLines    }  },  "ourApproach": *[_type == "ourApproach"][0] {    heading,    graySubHeading,    blueSubHeading,    steps[] {      _key,      title,      index,      description[]      }  },  "faq": *[_type == "faq"][0] {    heading,    faqItem[] {      _key,      question,      answer[]            }  },  "useCase": *[_type == "useCase"][0] {    heading,    subHeading,    description,      blueSection,       useCases[] {      _key,      title,      hook,      buttonText,      buttonLink,      objective[]{..., markDefs[]{...}},      painPoints[]{..., markDefs[]{...}},      solution[]{..., markDefs[]{...}},      benefits[]{..., markDefs[]{...}},      korefocusRole[]{..., markDefs[]{...}}    }  }}
+// Query: {  "hero": *[_type == "hero"][0] {    heading,    headingBlue,    image {      asset,      alt    },ctas[]    {    text,    linkText,    linkTarget,    }  },  "home": *[_type == "home"][0],  "whatWeDo": *[_type == "whatWeDo"][0] {    heading,    cards[] {      title,      subtitle,      buttonText,      buttonLink,      blueLines,      grayLines    }  },  "ourApproach": *[_type == "ourApproach"][0] {    heading,    graySubHeading,    blueSubHeading,    steps[] {      _key,      title,      index,      description[]      }  },  "faq": *[_type == "faq"][0] {    heading,    faqItem[] {      _key,      question,      answer[]            }  },  "useCase": *[_type == "useCase"][0] {    heading,    subHeading,    description,      blueSection,       useCases[] {      _key,      title,      hook,      buttonText,      buttonLink,      objective[]{..., markDefs[]{...}},      painPoints[]{..., markDefs[]{...}},      solution[]{..., markDefs[]{...}},      benefits[]{..., markDefs[]{...}},      korefocusRole[]{..., markDefs[]{...}}    }  }}
 export type QueryResult = {
   hero: {
     heading: string | null;
@@ -449,6 +451,11 @@ export type QueryResult = {
       } | null;
       alt: string | null;
     } | null;
+    ctas: Array<{
+      text: string | null;
+      linkText: string | null;
+      linkTarget: string | null;
+    }> | null;
   } | null;
   home: {
     _id: string;
@@ -799,12 +806,3 @@ export type UseCaseQueryResult = {
     }> | null;
   } | null;
 } | null;
-
-// Query TypeMap
-import '@sanity/client';
-// declare module '@sanity/client' {
-//   interface SanityQueries {
-//     '\n{\n  "hero": *[_type == "hero"][0] {\n    heading,\n    headingBlue,\n    image {\n      asset,\n      alt\n    }\n  },\n  "home": *[_type == "home"][0],\n  "whatWeDo": *[_type == "whatWeDo"][0] {\n    heading,\n    cards[] {\n      title,\n      subtitle,\n      buttonText,\n      buttonLink,\n      blueLines,\n      grayLines\n    }\n  },\n  "ourApproach": *[_type == "ourApproach"][0] {\n    heading,\n    graySubHeading,\n    blueSubHeading,\n    steps[] {\n      _key,\n      title,\n      index,\n      description[]  \n    }\n  },\n  "faq": *[_type == "faq"][0] {\n    heading,\n    faqItem[] {\n      _key,\n      question,\n      answer[]        \n    }\n  },\n  "useCase": *[_type == "useCase"][0] {\n    heading,\n    subHeading,\n    description,  \n    blueSection,   \n    useCases[] {\n      _key,\n      title,\n      hook,\n      buttonText,\n      buttonLink,\n      objective[]{..., markDefs[]{...}},\n      painPoints[]{..., markDefs[]{...}},\n      solution[]{..., markDefs[]{...}},\n      benefits[]{..., markDefs[]{...}},\n      korefocusRole[]{..., markDefs[]{...}}\n    }\n  }\n}\n': QueryResult;
-//     '\n  *[_type == "useCase"][0] {\n    "useCase": useCases[buttonLink == "/use-cases/" + $slug][0] {\n      title,\n      objective[]{..., markDefs[]{...}},\n      painPoints[]{..., markDefs[]{...}},\n      solution[]{..., markDefs[]{...}},\n      benefits[]{..., markDefs[]{...}},\n      korefocusRole[]{..., markDefs[]{...}}\n    }\n  }\n': UseCaseQueryResult;
-//   }
-// }


### PR DESCRIPTION
## Summary
- enable scroll snapping on the page container
- define a `fadeIn` motion variant
- use the new variant across homepage sections
- apply `snap-start` so each section snaps into place

## Testing
- `npm run lint`
