### PR TITLE
Add scroll snapping only on home layout

### DIFF
--- a/app/(home)/layout.tsx
+++ b/app/(home)/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 
 const HomeLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <div>
+    <div className="snap-y snap-mandatory overflow-y-scroll">
       {children}
       <Footer />
     </div>

--- a/components/faqs-section.tsx
+++ b/components/faqs-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion, useReducedMotion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import {
   Accordion,
   AccordionItem,
@@ -17,9 +18,13 @@ export default function FaqSection({ faq }: FaqProps) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
-      className="bg-accent min-h-[calc(100dvh-96px)] scroll-mt-24 py-12 text-white"
+    <motion.section
+      className="bg-accent min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 py-12 text-white"
       id="faq"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       {/* Heading */}
       <motion.h2
@@ -62,6 +67,6 @@ export default function FaqSection({ faq }: FaqProps) {
             : null}
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { urlFor } from '@/lib/sanity/client';
 import type { Hero } from '@/lib/sanity/types';
 import Image from 'next/image';
-import { fadeUp } from '@/lib/motion';
+import { fadeUp, fadeIn } from '@/lib/motion';
 import { Button } from './ui/button';
 import { ArrowRight } from 'lucide-react';
 
@@ -16,16 +16,26 @@ export default function HeroSection({ hero }: { hero: Hero }) {
     : '';
 
   return (
-    <div className="flex h-screen flex-col gap-12 px-4">
+    <div className="flex h-screen snap-start flex-col gap-12 px-4">
       {/* HERO */}
       <motion.section
         className="flex flex-col items-center gap-4 pt-8"
         initial={shouldReduce ? undefined : 'hidden'}
         animate="show"
-        variants={{
-          hidden: {},
-          show: { transition: { staggerChildren: 0.2 } },
-        }}
+        variants={
+          shouldReduce
+            ? {}
+            : {
+                hidden: fadeIn.hidden,
+                show: {
+                  ...fadeIn.show,
+                  transition: {
+                    ...fadeIn.show.transition,
+                    staggerChildren: 0.2,
+                  },
+                },
+              }
+        }
       >
         {imgSrc && (
           <motion.div

--- a/components/our-approach.tsx
+++ b/components/our-approach.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react';
 import Lenis from 'lenis';
 import { useScroll, motion, useReducedMotion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import type { OurApproach } from '@/lib/sanity/types';
 import ApproachCard from './approach-card';
 
@@ -29,10 +30,14 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
-      className="relative h-[2400px] scroll-mt-24 py-12"
+    <motion.section
+      className="relative h-[2400px] snap-start scroll-mt-24 py-12"
       ref={containerRef}
       id="how-we-work"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       <motion.div
         className="sticky top-[20vh] container mx-auto mb-4 max-w-[700px] px-4"
@@ -76,6 +81,6 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
           );
         })}
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/components/use-cases.tsx
+++ b/components/use-cases.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { motion, useReducedMotion, Variants } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import {
   Card,
   CardContent,
@@ -37,11 +38,11 @@ export const UseCases = ({ useCaseSection }: UseCasesProps) => {
   return (
     <motion.section
       id="use-cases"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white px-8 py-12 text-gray-900"
-      initial={shouldReduce ? {} : { opacity: 0, y: 20 }}
-      whileInView={shouldReduce ? {} : { opacity: 1, y: 0 }}
+      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white px-8 py-12 text-gray-900"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
       viewport={{ once: true, amount: 0.3 }}
-      transition={{ duration: 0.6 }}
+      variants={fadeIn}
     >
       <div className="mx-auto grid max-w-7xl grid-cols-1 gap-12 md:grid-cols-2">
         {/* Left Intro */}

--- a/components/what-we-do.tsx
+++ b/components/what-we-do.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useReducedMotion, motion } from 'framer-motion';
+import { fadeIn } from '@/lib/motion';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import type { WhatWeDo, WhatWeDoItem } from '@/lib/sanity/types';
@@ -20,9 +21,13 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
   const shouldReduce = useReducedMotion();
 
   return (
-    <section
+    <motion.section
       id="what-we-do"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white py-12"
+      className="min-h-[calc(100dvh-96px)] snap-start scroll-mt-24 bg-white py-12"
+      initial={shouldReduce ? {} : 'hidden'}
+      whileInView="show"
+      viewport={{ once: true, amount: 0.3 }}
+      variants={fadeIn}
     >
       <div className="container mx-auto mb-12 px-4 text-center">
         <h2 className="text-4xl font-extrabold text-gray-900">
@@ -97,6 +102,6 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
           );
         })}
       </div>
-    </section>
+    </motion.section>
   );
 }

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -11,3 +11,15 @@ export const fadeUp: Variants = {
     },
   },
 };
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      duration: 0.6,
+      ease: [0.25, 0.1, 0.25, 1],
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- scope scroll snapping to the home layout instead of the site root

## Testing
- `npm run lint` *(fails: `next` not found)*