### PR TITLE
Fix home page section heights

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,6 +46,7 @@
 
 :root {
   --radius: 0.625rem;
+  --navbar-height: clamp(3.5rem, 6vw, 4rem);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Navbar />
-        <div className="pt-16">{children}</div>
+        <div className="pt-[var(--navbar-height)]">{children}</div>
         <SanityLive />
         <Analytics />
         <SpeedInsights />

--- a/components/contact-us-section.tsx
+++ b/components/contact-us-section.tsx
@@ -50,7 +50,7 @@ export default function ContactUs() {
 
   return (
     <motion.section
-      className="h-full min-h-[calc(100dvh-96px)] scroll-mt-24 py-12"
+      className="h-full min-h-[calc(100dvh-var(--navbar-height))] scroll-mt-24 py-[clamp(3rem,5vw,6rem)]"
       id="faq"
       initial={'hidden'}
       whileInView="show"

--- a/components/faqs-section.tsx
+++ b/components/faqs-section.tsx
@@ -18,7 +18,7 @@ export default function FaqSection({ faq }: FaqProps) {
 
   return (
     <section
-      className="bg-accent min-h-[calc(100dvh-96px)] scroll-mt-24 py-12 text-white"
+      className="bg-accent min-h-[calc(100dvh-var(--navbar-height))] scroll-mt-24 py-[clamp(3rem,5vw,6rem)] text-white"
       id="faq"
     >
       {/* Heading */}

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -16,7 +16,7 @@ export default function HeroSection({ hero }: { hero: Hero }) {
     : '';
 
   return (
-    <div className="flex h-screen flex-col gap-12 px-4">
+    <div className="flex min-h-[calc(100dvh-var(--navbar-height))] flex-col gap-[clamp(2rem,4vw,3rem)] px-4">
       {/* HERO */}
       <motion.section
         className="flex flex-col items-center gap-4 pt-8"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -54,7 +54,7 @@ export default function Navbar() {
       animate={shouldReduce ? {} : { y: 0, opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      <div className="container mx-auto flex h-16 items-center justify-between px-4">
+      <div className="container mx-auto flex h-[var(--navbar-height)] items-center justify-between px-4">
         {/* Logo */}
         <motion.div
           initial={shouldReduce ? {} : { opacity: 0 }}
@@ -118,7 +118,7 @@ export default function Navbar() {
       </div>
 
       {/* Centered Desktop Nav */}
-      <nav className="pointer-events-none absolute inset-x-0 top-4 flex h-16 justify-center">
+      <nav className="pointer-events-none absolute inset-x-0 top-4 flex h-[var(--navbar-height)] justify-center">
         <ul className="bg-primary border-accent pointer-events-auto hidden space-x-4 rounded-full border p-4 text-sm font-medium text-white md:flex">
           {navItems.map((item, i) => (
             <motion.li

--- a/components/our-approach.tsx
+++ b/components/our-approach.tsx
@@ -30,7 +30,7 @@ export default function OurApproach({ approach }: { approach: OurApproach }) {
 
   return (
     <section
-      className="relative h-[2400px] scroll-mt-24 py-12"
+      className="relative h-[2400px] min-h-[calc(100dvh-var(--navbar-height))] scroll-mt-24 py-[clamp(3rem,5vw,6rem)]"
       ref={containerRef}
       id="how-we-work"
     >

--- a/components/use-cases.tsx
+++ b/components/use-cases.tsx
@@ -37,7 +37,7 @@ export const UseCases = ({ useCaseSection }: UseCasesProps) => {
   return (
     <motion.section
       id="use-cases"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white px-8 py-12 text-gray-900"
+      className="min-h-[calc(100dvh-var(--navbar-height))] scroll-mt-24 bg-white px-8 py-[clamp(3rem,5vw,6rem)] text-gray-900"
       initial={shouldReduce ? {} : { opacity: 0, y: 20 }}
       whileInView={shouldReduce ? {} : { opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}

--- a/components/what-we-do.tsx
+++ b/components/what-we-do.tsx
@@ -15,7 +15,7 @@ export default function WhatWeDo({ whatWeDo }: WhatWeDoProps) {
   return (
     <section
       id="what-we-do"
-      className="min-h-[calc(100dvh-96px)] scroll-mt-24 bg-white py-12"
+      className="min-h-[calc(100dvh-var(--navbar-height))] scroll-mt-24 bg-white py-[clamp(3rem,5vw,6rem)]"
     >
       <motion.div
         className="container mx-auto mb-8 max-w-[700px] px-4"


### PR DESCRIPTION
## Summary
- reduce vertical whitespace by making each home section minus navbar size
- use clamp for dynamic navbar height
- adjust hero section spacing

## Testing
- `npm run lint`